### PR TITLE
[TECH] Ajouter une phase d'installation des fichiers de configuration des mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,20 @@ Use with [Scalingo][]: `scalingo env-set BUILDPACK_URL=https://github.com/1024pi
 web: ./bin/powerpipe server --port $PORT
 ```
 
+## Config files
+
+You can copy put your config files for mods anywhere as *.ppc.erb* and they will be copied to the powerpipe config directory after a pass with *erb*.
+
+Example `datadog.ppc.erb`:
+
+```
+connection "datadog" {
+  plugin = "datadog"
+  api_key = "<%= ENV['DATADOG_API_KEY'] %>"
+  app_key = "<%= ENV['DATADOG_APP_KEY'] %>"
+  api_url = "https://api.datadoghq.com/"
+}
+```
+
 [powerpipe]: https://powerpipe.io/
 [scalingo]: https://scalingo.com/

--- a/bin/compile
+++ b/bin/compile
@@ -55,6 +55,11 @@ if ! command -v $bin_dir/powerpipe >/dev/null; then
 	exit 1
 fi
 
+echo "Installing config"
+mkdir -p $BUILD_DIR/.powerpipe/config
+find $BUILD_DIR -name "*.ppc.erb" -exec bash -c "erb {} > $BUILD_DIR/.powerpipe/config/\$(basename {} .erb)" \;
+echo "Successfully configured"
+
 echo "Installing mod dependencies"
 cd $BUILD_DIR && POWERPIPE_INSTALL_DIR=$BUILD_DIR/.powerpipe $bin_dir/powerpipe mod install --install-dir $BUILD_DIR/.powerpipe
 echo "Successfully installed mod dependencies"


### PR DESCRIPTION
## :unicorn: Problème
La configuration des mods dans Powerpipe se fait grâce à des fichiers .ppc. Néanmoins, ces fichiers de configuration ne sont pas installés par le buildpack.

## :robot: Proposition
Installer les fichiers de configuration des mods